### PR TITLE
Prevent excessive esc

### DIFF
--- a/benchmark/Benchmark.md
+++ b/benchmark/Benchmark.md
@@ -1,5 +1,21 @@
 # Benchmark of @fav/cli.text-style
 
+## v0.2.0
+
+Comparing with following modules:
+
+* [chalk](https://www.npmjs.com/package/chalk)
+* [ansi-colors](https://www.npmjs.com/package/ansi-colors)
+
+|         | @fav/cli.text-style(0.2.0) | chalk(2.4.2)  | ansi-colors(4.1.1) |
+|:--------|---------------------------:|--------------:|-------------------:|
+| Colors  |            226,622 ops/sec | 5,551 ops/sec |    131,774 ops/sec |
+| Nested  |             66,477 ops/sec | 5,174 ops/sec |     26,087 ops/sec |
+| Nested2 |             29,916 ops/sec | 4,876 ops/sec |     24,757 ops/sec |
+
+- Platform: Node.js 12.2.0 on Darwin 64-bit
+- Machine: Intel(R) Core(TM) i7-2620M CPU @ 2.70GHz, 16GB
+
 ## v0.1.0
 
 Comparing with following modules:

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -34,7 +34,11 @@ function testColors(styles, names) {
 }
 
 function testNested(styles, names) {
-  names.reduce((result, name) => styles[name](result));
+  names.reduce((result, name) => styles[name](result), 'bar');
+}
+
+function testNested2(styles, names) {
+  names.reduce((result, name) => 'A' + styles[name](result) + 'B', 'bar');
 }
 
 new BenchmarkTester()
@@ -47,5 +51,10 @@ new BenchmarkTester()
   .addTest('chalk', testNested)
   .addTest('ansi-colors', testNested)
   .runTest('Nested', colors)
+
+  .addTest('@fav/cli.text-style', testNested2)
+  .addTest('chalk', testNested2)
+  .addTest('ansi-colors', testNested2)
+  .runTest('Nested2', colors)
 
   .print();

--- a/lib/ansi.js
+++ b/lib/ansi.js
@@ -1,13 +1,29 @@
 'use strict';
 
-function wrap(openCd, closeCd, closeRe) {
+function wrap(openCd, closeCd, groupRe) {
+  groupRe = groupRe || new RegExp('\\u001b\\[' + openCd + 'm');
+
+  var openEsc = esc(openCd);
+  var closeEsc = esc(closeCd);
+
+  var startRe = new RegExp('^' + groupRe.source);
+  var endRe = new RegExp('\\u001b\\[' + closeCd + 'm$');
+  var closeRe = new RegExp(
+    '(\\u001b\\[' + closeCd + 'm|\\u001b\\[0m|\\n)' +
+    '(?!' + groupRe.source + ').+');
+
   return function(text) {
     if (text == null || text === '') {
       return '';
     }
-    var openEsc = esc(openCd);
-    var closeEsc = esc(closeCd);
-    return openEsc + resolveNest(text, openEsc, closeEsc, closeRe) + closeEsc;
+    text = resolveNest(text, openEsc, closeEsc, closeRe);
+    if (!startRe.test(text)) {
+      text = openEsc + text;
+    }
+    if (!endRe.test(text)) {
+      text = text + closeEsc;
+    }
+    return text;
   };
 }
 
@@ -18,27 +34,27 @@ function esc(cd) {
 function resolveNest(text, openEsc, closeEsc, closeRe) {
   var m, ret = '';
   while (m = text.match(closeRe)) {
-    switch (m[0]) {
+    switch (m[1]) {
       case '\n': {
-        ret += text.slice(0, m.index) + closeEsc + m[0] + openEsc;
+        ret += text.slice(0, m.index) + closeEsc + m[1] + openEsc;
         break;
       }
       default: {
-        ret += text.slice(0, m.index + m[0].length) + openEsc;
+        ret += text.slice(0, m.index + m[1].length) + openEsc;
         break;
       }
     }
-    text = text.slice(m.index + m[0].length);
+    text = text.slice(m.index + m[1].length);
   }
   return ret + text;
 }
 
 function fgColor(openCd) {
-  return wrap(openCd, 39, /(\u001b\[39m|\u001b\[0m|\n)/);
+  return wrap(openCd, 39, /\u001b\[3[\d][^m]*m/);
 }
 
 function bgColor(openCd) {
-  return wrap(openCd, 49, /(\u001b\[49m|\u001b\[0m|\n)/);
+  return wrap(openCd, 49, /\u001b\[4[\d][^m]*m/);
 }
 
 function fg256Color(code) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha test",
+    "test": "mocha --recursive",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm test",
     "coveralls": "nyc --reporter=text-lcov npm test | coveralls",
     "build": "npm run lint && npm run coverage"

--- a/test/lib/ansi.test.js
+++ b/test/lib/ansi.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var ansi = require('../../lib/ansi');
+
+describe('lib/ansi', function() {
+   describe('esc', function() {
+     it('Should return escape sequence of the specified code', function() {
+       expect(ansi.esc(31)).to.equal('\u001b[31m');
+       expect(ansi.esc(39)).to.equal('\u001b[39m');
+     });
+   });
+
+   describe('wrap', function() {
+     it('Should wrap a text (with groupRe)', function() {
+       var fn31 = ansi.wrap(31, 39, /\u001b\[3[\d][^m]*m/);
+       var fn32 = ansi.wrap(32, 39, /\u001b\[3[\d][^m]*m/);
+       var fn33 = ansi.wrap(33, 39, /\u001b\[3[\d][^m]*m/);
+
+       var text = fn31('AAA');
+       expect(text).to.equal('\u001b[31mAAA\u001b[39m');
+
+       text = fn32(text);
+       expect(text).to.equal('\u001b[31mAAA\u001b[39m');
+
+       text = fn32('BBB' + text);
+       expect(text).to.equal('\u001b[32mBBB\u001b[31mAAA\u001b[39m');
+
+       text = fn33(text + 'CCC');
+       expect(text).to.equal(
+         '\u001b[32mBBB\u001b[31mAAA\u001b[39m\u001b[33mCCC\u001b[39m');
+
+       text = fn33('D' + text + 'E');
+       expect(text).to.equal(
+         '\u001b[33mD\u001b[32mBBB\u001b[31mAAA\u001b[39m\u001b[33mCCC' +
+         '\u001b[39m\u001b[33mE\u001b[39m');
+
+       text = fn33(text);
+       expect(text).to.equal(
+         '\u001b[33mD\u001b[32mBBB\u001b[31mAAA\u001b[39m\u001b[33mCCC' +
+         '\u001b[39m\u001b[33mE\u001b[39m');
+     });
+
+     it('Should wrap a text (with no groupRe)', function() {
+       var fn4 = ansi.wrap(4, 24);
+
+       var text = fn4('AAA');
+       expect(text).to.equal('\u001b[4mAAA\u001b[24m');
+
+       text = fn4(text);
+       expect(text).to.equal('\u001b[4mAAA\u001b[24m');
+
+       text = fn4('BBB' + text);
+       expect(text).to.equal('\u001b[4mBBB\u001b[4mAAA\u001b[24m');
+
+       text = fn4(text + 'CCC');
+       expect(text).to.equal('\u001b[4mBBB\u001b[4mAAA\u001b[24m\u001b[4m' +
+         'CCC\u001b[24m');
+     });
+
+     it('Should not wrap an empty text', function() {
+       var fn31 = ansi.wrap(31, 39, /\u001b\[3[\d][^m]*m/);
+       expect(fn31()).to.equal('');
+       expect(fn31('')).to.equal('');
+     });
+
+     it('Should wrap a text including line breaks', function() {
+       var fn31 = ansi.wrap(31, 39, /\u001b\[3[\d][^m]*m/);
+       var text = 'AAA\nBBB\nCCC';
+
+       text = fn31(text);
+       expect(text).to.equal(
+         '\u001b[31mAAA\u001b[39m\n' +
+         '\u001b[31mBBB\u001b[39m\n' +
+         '\u001b[31mCCC\u001b[39m');
+
+       text = fn31(text);
+       expect(text).to.equal(
+         '\u001b[31mAAA\u001b[39m\n' +
+         '\u001b[31mBBB\u001b[39m\n' +
+         '\u001b[31mCCC\u001b[39m');
+     });
+   });
+
+   describe('noEffect', function() {
+     it('Should add no esc', function() {
+       var text = ansi.noEffect('AAA');
+       expect(text).to.equal('AAA');
+
+       text = ansi.noEffect(text);
+       expect(text).to.equal('AAA');
+
+       text = ansi.noEffect('');
+       expect(text).to.equal('');
+
+       text = ansi.noEffect();
+       expect(text).to.equal('');
+     });
+   });
+
+   describe('fg16Color', function() {
+     it('Should add fg color esc', function() {
+       var fn31 = ansi.fg16Color(31);
+       var text = fn31('AAA');
+       expect(text).to.equal('\u001b[31mAAA\u001b[39m');
+     });
+   });
+
+   describe('bg16Color', function() {
+     it('Should add bg color esc', function() {
+       var fn41 = ansi.bg16Color(41);
+       var text = fn41('AAA');
+       expect(text).to.equal('\u001b[41mAAA\u001b[49m');
+     });
+   });
+
+   describe('fg256Color', function() {
+     it('Should add fg color esc', function() {
+       var fn1 = ansi.fg256Color(1);
+       var text = fn1('AAA');
+       expect(text).to.equal('\u001b[38;1mAAA\u001b[39m');
+     });
+   });
+
+   describe('bg256Color', function() {
+     it('Should add bg color esc', function() {
+       var fn1 = ansi.bg256Color(1);
+       var text = fn1('AAA');
+       expect(text).to.equal('\u001b[48;1mAAA\u001b[49m');
+     });
+   });
+
+   describe('fg16mColor', function() {
+     it('Should add fg color esc', function() {
+       var fn1 = ansi.fg16mColor(1, 2, 3);
+       var text = fn1('AAA');
+       expect(text).to.equal('\u001b[38;2;1;2;3mAAA\u001b[39m');
+     });
+   });
+
+   describe('bg16mColor', function() {
+     it('Should add bg color esc', function() {
+       var fn1 = ansi.bg16mColor(1, 2, 3);
+       var text = fn1('AAA');
+       expect(text).to.equal('\u001b[48;2;1;2;3mAAA\u001b[49m');
+     });
+   });
+});


### PR DESCRIPTION
This pr prevents to add excessive ESCs for nested styled texts.

```js
// Example 1)
const styles = require('@fav/cli.text-style');
styles.red(styles.blue(styles.green('AAA')));

// Before) 
// => '\u001b[31m\u001b[34m\u001b[32mAAA\u001b[39m\u001b[31m\u001b[34m\u001b[39m\u001b[31m\u001b[39m'

// After)
// => '\u001b[32mAAA\u001b[39m'
```

```js
// Example 2)
styles.red(styles.blue('BBB' + styles.green('AAA') + 'CCC'));

// Before)
// => '\u001b[31m\u001b[34mBBB\u001b[32mAAA\u001b[39m\u001b[31m\u001b[34mCCC\u001b[39m\u001b[31m\u001b[39m'

// After)
// => '\u001b[34mBBB\u001b[32mAAA\u001b[39m\u001b[34mCCC\u001b[39m'
```
